### PR TITLE
Fix: config & CI/CD

### DIFF
--- a/.github/workflows/sstDeploy.yaml
+++ b/.github/workflows/sstDeploy.yaml
@@ -8,6 +8,7 @@ on:
   #     - dev
   #   types:
   #     - closed
+  # 手動でワークフローを実行する場合はこちら
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sstDeploy.yaml
+++ b/.github/workflows/sstDeploy.yaml
@@ -34,7 +34,7 @@ jobs:
             echo "stage_name=dev" >> $GITHUB_OUTPUT
           fi
 
-  aws-login:
+  deploy:
     needs: set-stage-name
     runs-on: ubuntu-latest
     environment: ${{ needs.set-stage-name.outputs.stage_name }}
@@ -47,13 +47,6 @@ jobs:
         with:
           role-to-assume: "arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.ASSUME_ROLE_NAME }}"
           aws-region: ap-northeast-1
-
-  sst-deploy:
-    needs: [set-stage-name, aws-login]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -16,25 +16,49 @@ https://sst.dev/docs/environment-variables/#_top
 ### 作成
 
 ```
-npx sst secret set <name> [value] --stage dev
+<!-- local環境 -->
+AWS_PROFILE={{profile名}} npx sst secret set <name> [value]
+<!-- dev環境 -->
+AWS_PROFILE={{profile名}} npx sst secret set <name> [value] --stage dev
 ```
 
 ### 確認
 
 ```
-npx sst secret list --stage dev
+<!-- local環境 -->
+AWS_PROFILE={{profile名}} npx sst secret list
+<!-- dev環境 -->
+AWS_PROFILE={{profile名}} npx sst secret list --stage dev
 ```
 
 ### 削除
 
 ```
-npx sst secret remove <name> --stage dev
+<!-- local環境 -->
+AWS_PROFILE={{profile名}} npx sst secret remove <name>
+<!-- dev環境 -->
+AWS_PROFILE={{profile名}} npx sst secret remove <name> --stage dev
+```
+
+## local development
+
+```
+AWS_PROFILE={{profile名}} npx sst dev
 ```
 
 ## deploy
 
-AWS の profile は sst.config.ts の設定により、stage に応じて切り替えられます。
+```
+AWS_PROFILE={{profile名}} npx sst deploy --stage dev
+```
 
-```
-npx sst deploy --stage dev
-```
+## CI/CD
+
+GitHub Actions で sst deploy を実行します。
+
+事前準備として、Assume Role するための IAM ロールの作成を行ってください。
+また、GitHub Actions の環境作成（prod, stage, dev）・シークレット（AWS_ACCOUNT_ID, ASSUME_ROLE_NAME） の登録も行ってください。
+ブランチの運用は main, stage, dev とします。
+
+参考：
+https://qiita.com/generoKoki/items/bcf87549a18a1481d62e

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -6,23 +6,6 @@ export default $config({
       name: "aws-nuxt",
       removal: input?.stage === "prod" ? "retain" : "remove",
       home: "aws",
-      providers: {
-        aws: {
-          // 環境毎にプロファイルを切り替える
-          profile: (() => {
-            switch (input?.stage) {
-              case "prod":
-                return "jyp-mirrorsnap-pro-prod";
-              case "stage":
-                return "jyp-mirrorsnap-pro-stage";
-              case "dev":
-                return "jyp-mirrorsnap-pro-stage";
-              default:
-                throw new Error(`Unknown stage: ${input.stage}`);
-            }
-          })()
-        }
-      }
     };
   },
   async run() {


### PR DESCRIPTION
- sst.config.tsのprofile設定を削除
  - Github Actionsでsst deploy時にprofileの設定が確認できずエラーが出るため
- READMEの各sstコマンドに対して、AWS_PROFILE環境変数を与える形に修正
- CI/CD欄を追加し、Github Actionsのworkflowを正しく動かすための前準備を記載