### PR TITLE
add: Origin Setting in CloudFront & Lambda Authorizer in HTTP API Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ AWS_PROFILE={{profile名}} npx sst secret remove <name> --stage dev
 AWS_PROFILE={{profile名}} npx sst dev
 ```
 
+AWS 管理画面を開き、開発用 API Gateway の Route にアタッチされている Lambda Authorizer を デタッチしてから開発します。
+
 ## deploy
 
 ```

--- a/app.vue
+++ b/app.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
     <NuxtRouteAnnouncer />
-    <NuxtWelcome />
+    <NuxtLayout>
+      <NuxtPage />
+    </NuxtLayout>
   </div>
 </template>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.716.0",
+        "@types/aws-lambda": "^8.10.146",
         "nuxt": "3.13.2",
         "sst": "3.4.32",
         "vue": "latest",
@@ -4416,6 +4417,11 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.146",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.146.tgz",
+      "integrity": "sha512-3BaDXYTh0e6UCJYL/jwV/3+GRslSc08toAiZSmleYtkAUyV5rtvdPYxrG/88uqvTuT6sb27WE9OS90ZNTIuQ0g=="
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
@@ -9823,6 +9829,13 @@
         }
       ]
     },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/scule": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
@@ -11923,6 +11936,30 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.716.0",
+    "@types/aws-lambda": "^8.10.146",
     "nuxt": "3.13.2",
     "sst": "3.4.32",
     "vue": "latest",

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <div>
+    <h1>about</h1>
+  </div>
+</template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <div>
+    <h1>index</h1>
+  </div>
+</template>

--- a/src/authorizer.ts
+++ b/src/authorizer.ts
@@ -1,0 +1,26 @@
+import { APIGatewayEvent } from 'aws-lambda';
+import { Resource } from "sst";
+
+export const handler = async (
+  event: APIGatewayEvent,
+): Promise<{ isAuthorized: boolean; context?: any }> => {
+  const originVerify = event.headers?.['x-origin-verify'];
+
+  try {
+    // リクエストのヘッダーに含まれるトークンと、シークレットマネージャーに保存されているトークンが一致しているかチェックする
+    if (originVerify === Resource.VerifyToken.value) {
+      return {
+        isAuthorized: true,
+        context: {
+          user: 'user',
+        },
+      };
+    }
+  } catch (error) {
+    console.error('Error retrieving secret:', error);
+  }
+
+  return {
+    isAuthorized: false,
+  };
+};

--- a/src/authorizer.ts
+++ b/src/authorizer.ts
@@ -7,7 +7,7 @@ export const handler = async (
   const originVerify = event.headers?.['x-origin-verify'];
 
   try {
-    // リクエストのヘッダーに含まれるトークンと、シークレットマネージャーに保存されているトークンが一致しているかチェックする
+    // リクエストのヘッダーに含まれるトークンと、sst secretに保存されているトークンが一致しているかチェックする
     if (originVerify === Resource.VerifyToken.value) {
       return {
         isAuthorized: true,

--- a/src/get.ts
+++ b/src/get.ts
@@ -3,7 +3,7 @@ import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
 
 export async function handler() {
   console.log(process.env.DEBUG, "get");
-  console.log("password", Resource.TestPassword.value);
+  console.log("verifyToken", Resource.VerifyToken.value);
 
   const client = new DynamoDBClient();
 

--- a/sst-env.d.ts
+++ b/sst-env.d.ts
@@ -6,6 +6,14 @@ import "sst"
 export {}
 declare module "sst" {
   export interface Resource {
+    "BasicAuthPassword": {
+      "type": "sst.sst.Secret"
+      "value": string
+    }
+    "BasicAuthUserName": {
+      "type": "sst.sst.Secret"
+      "value": string
+    }
     "Domain": {
       "type": "sst.sst.Secret"
       "value": string
@@ -13,6 +21,10 @@ declare module "sst" {
     "MyApi": {
       "type": "sst.aws.ApiGatewayV2"
       "url": string
+    }
+    "MyApiAuthorizerLambdaAuthorizerFunction": {
+      "name": string
+      "type": "sst.aws.Function"
     }
     "MyTable": {
       "name": string
@@ -22,7 +34,7 @@ declare module "sst" {
       "type": "sst.aws.StaticSite"
       "url": string
     }
-    "TestPassword": {
+    "VerifyToken": {
       "type": "sst.sst.Secret"
       "value": string
     }

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -10,16 +10,115 @@ export default $config({
   },
   async run() {
     const domainSecret = new sst.Secret("Domain");
-    const passwordSecret = new sst.Secret("TestPassword");
-    // basic auth
-    // const username = new sst.Secret("BasicAuthUserName");
-    // const password = new sst.Secret("BasicAuthPassword");
+    const verifyTokenSecret = new sst.Secret("VerifyToken");
+    const username = new sst.Secret("BasicAuthUserName");
+    const password = new sst.Secret("BasicAuthPassword");
 
-    // const basicAuth = $resolve([username.value, password.value]).apply(
-    //   ([username, password]) =>
-    //     Buffer.from(`${username}:${password}`).toString("base64")
-    // );
+    const basicAuth = $resolve([username.value, password.value]).apply(
+      ([username, password]) =>
+        Buffer.from(`${username}:${password}`).toString("base64")
+    );
 
+    // DynamoDB Settings
+    const table = new sst.aws.Dynamo("MyTable", {
+      fields: {
+        code: "string"
+      },
+      primaryIndex: { hashKey: "code" }
+    });
+
+
+    // API Gateway Settings
+    const api = new sst.aws.ApiGatewayV2("MyApi", {
+      cors: {
+        allowOrigins: [
+          $resolve(domainSecret.value).apply(domain => `https://${domain}`),
+          "http://localhost:3000"
+        ]
+      }
+    });
+
+    // 認可
+    const lambdaAuthorizer = api.addAuthorizer({
+      name: "lambdaAuthorizer",
+      lambda: {
+        function: {
+          handler: "src/authorizer.handler",
+          architecture: "arm64", // x86 よりもコスト安い
+          link: [verifyTokenSecret],
+          logging: {
+            format: "json",
+          },
+        },
+        identitySources: ["$request.header.x-origin-verify"],
+      },
+    });
+
+    // API Route
+    api.route("GET /api/get",
+      {
+        handler: "src/get.handler",
+        architecture: "arm64",
+        link: [table, verifyTokenSecret],
+        environment: {
+          DEBUG: "true",
+        },
+        logging: {
+          format: "json",
+        },
+      },
+      {
+        auth: {
+          lambda: lambdaAuthorizer.id,
+        },
+      }
+    );
+
+    api.route("POST /api/post",
+      {
+        handler: "src/post.handler",
+        architecture: "arm64",
+        link: [table],
+        logging: {
+          format: "json",
+        },
+      },
+      {
+        auth: {
+          lambda: lambdaAuthorizer.id,
+        },
+      }
+    );
+
+
+    // CloudFront Settings
+    const origin = {
+      domainName: $resolve(api.url).apply(url => new URL(url).host), // https://の除去を行い、ドメインのみ抽出する
+      originId: "apiOrigin", // オリジン名になる
+      customOriginConfig: {
+        httpPort: 80,
+        httpsPort: 443,
+        originSslProtocols: ["TLSv1.2"],
+        originProtocolPolicy: "https-only",
+      },
+      customHeaders: [{
+        name: "x-origin-verify",
+        value: verifyTokenSecret.value,
+      }],
+    };
+
+    const cacheBehavior = {
+      pathPattern: "/api/*",
+      targetOriginId: origin.originId,
+      viewerProtocolPolicy: "redirect-to-https",
+      allowedMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"],
+      cachedMethods: ["GET", "HEAD"],
+      cachePolicyId: "4135ea2d-6df8-44a3-9df3-4b5a84be39ad", // CachingDisabled
+      originRequestPolicyId: "b689b0a8-53d0-40ab-baf2-68738e2966ac", // AllViewerExceptHostHeader
+    };
+
+
+    // Static Site Settings
     new sst.aws.StaticSite("MyWeb", {
       domain: {
         name: domainSecret.value
@@ -32,66 +131,32 @@ export default $config({
         command: "npm run generate",
         output: ".output/public"
       },
-      // server: {
-      //   edge: {
-      //     viewerRequest: {
-      //       injection: $interpolate`
-      //         // basic auth
-      //         if (
-      //           !event.request.headers.authorization
-      //             || event.request.headers.authorization.value !== "Basic ${basicAuth}"
-      //         ) {
-      //           return {
-      //             statusCode: 401,
-      //             headers: {
-      //               "www-authenticate": { value: "Basic" }
-      //             }
-      //           };
-      //         }
+      transform: {
+        cdn: (options: sst.aws.CdnArgs) => {
+          options.origins = $resolve(options.origins).apply(val => [...val, origin]);
 
-      //         // spa routing
-      //         if (event.request.method === "GET" && event.request.uri.indexOf(".") === -1) {
-      //           event.request.uri = '/' + indexPage;
-      //         }
-
-      //         return event.request;
-      //       }`,
-      //     }
-      //   }
-      // }
-    });
-
-    const api = new sst.aws.ApiGatewayV2("MyApi", {
-      // cors: {
-      //   allowOrigins: [domainSecret.value, "http://localhost:3000"]
-      // }
-    });
-
-    const table = new sst.aws.Dynamo("MyTable", {
-      fields: {
-        code: "string"
+          options.orderedCacheBehaviors = $resolve(
+            options.orderedCacheBehaviors || []
+          ).apply(val => [...val, cacheBehavior]);
+        },
       },
-      primaryIndex: { hashKey: "code" }
-    });
-
-    api.route("GET /", {
-      handler: "src/get.handler",
-      architecture: "arm64", // x86 よりもコスト安い
-      link: [table, passwordSecret],
-      environment: {
-        DEBUG: "true",
-      },
-      logging: {
-        format: "json",
-      },
-    });
-
-    api.route("POST /", {
-      handler: "src/post.handler",
-      architecture: "arm64", // x86 よりもコスト安い
-      link: [table],
-      logging: {
-        format: "json",
+      edge: {
+        viewerRequest: {
+          injection: $interpolate`
+            // basic auth
+            if (
+              !event.request.headers.authorization
+                || event.request.headers.authorization.value !== "Basic ${basicAuth}"
+            ) {
+              return {
+                statusCode: 401,
+                headers: {
+                  "www-authenticate": { value: "Basic" }
+                }
+              };
+            }
+          `
+        }
       },
     });
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,18 @@
 {
   // https://nuxt.com/docs/guide/concepts/typescript
-  "extends": "./.nuxt/tsconfig.json"
+  "extends": "./.nuxt/tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "preserveConstEnums": true,
+    "sourceMap": false,
+    "target": "es2020",
+    "strict": true,
+    "verbatimModuleSyntax": false,
+  },
+  "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
- CloudFrontのオリジンにAPI Gatewayを追加し、諸々設定追加
- API Gatewayの認可にLambda Authorizerを追加
- CORSのオリジン許可設定追加
- CloudFrontFunctionとしてBasic認証追加